### PR TITLE
temporarily resolved issues with ws subscription termination.

### DIFF
--- a/generic/generic.py
+++ b/generic/generic.py
@@ -198,7 +198,7 @@ def get_string_value(source:str, default:int, valid_values:list=None, show_exit:
             if is_blank(val):
                 # Returns default if input is blank/whitespace
                 print(f"Using default for {source}: {default}")
-                return valid_values[default]
+                return valid_values[default-1]
             
             if not use_str_input:
                 # Continues the loop if string input is received, but use_str_input is disabled for selecting options 


### PR DESCRIPTION
Fixed Issues when calling the `terminate()` function where the internal timer thread throws an error. 

**Issue 1:** 
Thread from websocket throws an error (WebSocketConnectionClosed), but does not hinder functionality 

**Cause:**
 `_send_initial_ping()` and `_send_custom_ping()` 

**Solution(Temporary):** 
Modify Timer variable in `_send_custom_ping()` as class member variable (self.timer), and kill the thread manually to silence the Exception. Also throws the same exception if `self.ws.exit()` is called prior to killing the thread. Solution: kill the thread first, then exit. 

**Issue 2:** 
Callback function still executes after killing the timer thread and exit. 

**Solution(Temporary):** 
Created a class member variable: `self.running` to determine if termination method is called, or if subscription to WS is called. Is set to false when termination function is called, sets to true if subscription function 
is called. 