### PR TITLE
changed method for returning strategy config defaults

### DIFF
--- a/strategies/base/configs.py
+++ b/strategies/base/configs.py
@@ -5,7 +5,7 @@ class Configs:
     def __init__(self):
         pass
 
-    def check_strategy(self, strategy_config:dict, strategy:any): 
+    def check_strategy(self, strategy_config:dict, strategy:object): 
         """
         Attempts to unpack the strategy configuration from .ini file, into config dataclass. 
 
@@ -18,3 +18,12 @@ class Configs:
         # Unppack Config
         return strategy(**strategy_config)
         
+        
+    @staticmethod 
+    def get_default_strategy_config_values(strategy:object) -> list:
+        """
+        Returns default values of a strategy configuration as a list. 
+
+        This is called when errors are raised while parsing input parameters from .ini file. 
+        """
+        return list(strategy().__dict__.values())

--- a/strategies/ma_cross/ma_cross.py
+++ b/strategies/ma_cross/ma_cross.py
@@ -94,11 +94,9 @@ class MACross(Strategy, Configs):
 
         # If any errors are found, Defaults are used. 
         print("Invalid config file. Setting Defaults.")
-        fast = 20
-        slow = 100 
-        ma_kind = MAType.SIMPLE 
 
-        return fast, slow, ma_kind
+        return self.get_default_strategy_config_values(MACrossConfigs)
+
 
     
     @staticmethod

--- a/strategies/mean_reversion/mean_reversion.py
+++ b/strategies/mean_reversion/mean_reversion.py
@@ -17,24 +17,34 @@ class MeanReversionConfigs:
     ma_kind:MAType=MAType.SIMPLE # Moving average type 
 
 
-class MeanReversion(Strategy):
+class MeanReversion(Strategy, Configs):
     def __init__(
             self,
             config:TradeConfig, 
             strategy_config:dict
         ):
-        super().__init__("Mean Reversion", config)
-
+        
+        Strategy.__init__(self, name="Mean Reversion", config=config)
+        Configs.__init__(self)
 
         self.strategy=self.check_strategy(strategy_config, MeanReversionConfigs)
+
         
 
     def __set_strategy_configs(self, strategy:MeanReversionConfigs): 
         try:
-            pass
+            mean_period = int(strategy.mean_period)
+            spread_mean_period = int(strategy.spread_mean_period)
+            spread_sdev_period = int(strategy.spread_sdev_period)
+            threshold = float(strategy.threshold)
+            ma_kind = self.__select_ma_type(strategy.ma_kind)
+            
+            return mean_period, spread_mean_period, spread_sdev_period, threshold, ma_kind 
         except:
             pass 
             
+
+
 
     @staticmethod 
     def __select_ma_type(kind:str) -> MAType: 

--- a/tests/test_ma_cross.py
+++ b/tests/test_ma_cross.py
@@ -30,7 +30,12 @@ class TestMACrossStrategy(unittest.TestCase):
             strategy_config=self.strategy_config_dict
         )
 
-
+    def test_faulty_strat_config(self):
+        strat_config = {"fast_ma_period" : "20", "slow_ma_period" : "wrong_value", "ma_kind" : "invalid"}
+        strategy = MACross(
+            config=self.trade_config,
+            strategy_config=strat_config
+        )
         
     def test_side(self): 
         """


### PR DESCRIPTION
- Created method for returning strategy defaults when errors were raised while parsing input parameters from .ini file. 
- Unpacks strategy config defaults into list.
- Updated unittest to account for this method